### PR TITLE
Add Vagrantfile for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.vagrant
 *.local
+*.log

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Ansible Playground
 
 This repository is intended as an entry point into an ownCloud deployment with Ansible and will also act as a showcase and documentation for possible deployment trategies.
+
+# Testing
+
+## Testing using Vagrant
+
+Vagrant makes it possible to run Ansible scripts inside a virtual machine (backed by VirtualBox).
+
+- For the first time setup, please run `vagrant up`.
+- Then after making changes to the playbooks, roles or inventory, please run `vagrant provision` to apply the changes to the virtual machine.
+- The deployed ownCloud instance is accessible under http://172.30.1.2/ with user "admin" and password "owncloud".
+- The command `vagrant ssh` makes it possible to enter the VM for debugging purposes.
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+Vagrant.require_version ">= 2.0.0"
+
+Vagrant.configure(2) do |config|
+
+ config.vm.box = "ubuntu/bionic64"
+ config.vm.network 'private_network', ip: '172.30.1.2'
+ config.vm.provision "ansible_local" do |ansible|
+   ansible.verbose = "v"
+   ansible.playbook = "playbooks/setup.yml"
+   ansible.galaxy_role_file = "roles/requirements.yml"
+   ansible.galaxy_roles_path = "/home/vagrant/.ansible/roles"
+   ansible.inventory_path = "inventories/vagrant/hosts"
+   ansible.limit = "all"
+ end
+
+end

--- a/inventories/vagrant/group_vars/database.yml
+++ b/inventories/vagrant/group_vars/database.yml
@@ -1,0 +1,12 @@
+---
+# For security reasons you should set a strong password
+# for the owncloud DB and root user!
+mariadb_root_password: root
+
+mariadb_users:
+  - name: owncloud
+    host: localhost
+    password: owncloud
+    priv: "owncloud.*:ALL"
+
+...

--- a/inventories/vagrant/group_vars/owncloud.yml
+++ b/inventories/vagrant/group_vars/owncloud.yml
@@ -1,0 +1,28 @@
+---
+owncloud_version: "10.3.1"
+owncloud_fqdn: vagrant.owncloud.demo
+
+# If you would like to access your ownCloud by IP
+# you can add it to trusted domains.
+owncloud_trusted_domains:
+  - "{{ owncloud_fqdn }}"
+  - "{{ ansible_default_ipv4.address }}"
+  - "172.30.1.2"
+
+# Adjust these variable to the same values defined in
+# group_vars/database.yml
+owncloud_db_name: owncloud
+owncloud_db_user: owncloud
+owncloud_db_password: owncloud
+
+# You can also adjust the default ownCloud user.
+# For security reasons you should set a strong password!
+owncloud_admin_username: admin
+owncloud_admin_password: owncloud
+
+owncloud_log_timezone: "Etc/UTC"
+owncloud_log_dateformat: "Y-m-d H:i:s.u"
+
+php_date_timezone: "{{ owncloud_log_timezone }}"
+
+...

--- a/inventories/vagrant/hosts
+++ b/inventories/vagrant/hosts
@@ -1,0 +1,13 @@
+[all:vars]
+ansible_become=True
+ansible_user=root
+ansible_connection=local
+
+[database]
+db1
+
+[redis]
+redis1
+
+[owncloud]
+owncloud1 


### PR DESCRIPTION
Fixes https://github.com/owncloud-ansible/playground/issues/1

This uses "ansible_local" mode which will install Ansible inside the Vagrant VM, so this is likely only suitable for single machine development.

Also I had to use some hard-coded IPs as the IP detected by Ansible doesn't match this one.

While not a perfect solution, this is still a great way to work and test Ansible roles.
